### PR TITLE
fix: use sso auth uri as keycloak base

### DIFF
--- a/config/env/env.go
+++ b/config/env/env.go
@@ -22,7 +22,7 @@ func MongoUsername() string {
 }
 
 func KeycloakHost() string {
-	return getEnv("KEYCLOAK_HOST", "https://sso.staging.fellesdatakatalog.digdir.no")
+	return getEnv("SSO_AUTH_URI", "https://sso.staging.fellesdatakatalog.digdir.no/auth")
 }
 
 type Constants struct {

--- a/deploy/staging/env.yaml
+++ b/deploy/staging/env.yaml
@@ -26,3 +26,8 @@ spec:
                 secretKeyRef:
                   name: mongo-staging
                   key: MONGO_PASSWORD
+            - name: SSO_AUTH_URI
+              valueFrom:
+                secretKeyRef:
+                  name: commonurl-staging
+                  key: SSO_AUTH_URI

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -39,7 +39,7 @@ func OrgReadAuth(org string) string {
 
 func TestMain(m *testing.M) {
 	mockJwkStore := MockJwkStore()
-	os.Setenv("KEYCLOAK_HOST", mockJwkStore.URL)
+	os.Setenv("SSO_AUTH_URI", mockJwkStore.URL)
 
 	MongoContainerRunner(m)
 }


### PR DESCRIPTION
Nyere versjoner av keycloak bruker ikke /auth som default path, vi har videreført den når vi har oppgradert, så må spesifisere uri med /auth til gocloak